### PR TITLE
i18n issues with <TopBar> where <MenuOption> height is a set height

### DIFF
--- a/src/top-bar/TopBar.js
+++ b/src/top-bar/TopBar.js
@@ -82,7 +82,7 @@ const menuTriggerStyles = {
 
 const menuOptionStyles = {
   optionWrapper: {
-    height: 48,
+    minHeight: 48,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-start',

--- a/src/top-bar/TopBar.js
+++ b/src/top-bar/TopBar.js
@@ -52,6 +52,7 @@ const styles = StyleSheet.create({
   menuOptionText: {
     flex: 1,
     fontSize: 15,
+    lineHeight: 20,
     color: '#212121',
     marginLeft: 7,
   },


### PR DESCRIPTION
Use `minHeight` over `height` to allow longer text which wraps onto a new line.

While translating our app to French, we ended up with a lot longer strings in these components causing them to wrap onto a new line. This obviously doesn't look good with a set height:
<image src="https://user-images.githubusercontent.com/1238485/78250108-47daa400-74e7-11ea-941c-1d11fa3117aa.jpg" width="200">

Changing it to use `minHeight` fixes the problem for us:
<image src="https://user-images.githubusercontent.com/1238485/78250156-5aed7400-74e7-11ea-9c5d-506bb2dfec7d.jpg" width="200">
